### PR TITLE
Unhandled exception when calling rmdir on non-existent file or directory

### DIFF
--- a/lib/rmdir.js
+++ b/lib/rmdir.js
@@ -16,6 +16,8 @@ function rmdir( dir, callback ){
     var _files = [];
     var _dirs  = [];
 
+    if( err ) return callback( err, _dirs, _files );
+
     if( !is_dir ){
       return fs.unlink( _dir, function ( err ){
         return err


### PR DESCRIPTION
If you call rmdir on a non-existent file or directory, the library currently throws an exception, that is impossible to handle because it is called asynchronously. This fix returns the error in the callback instead.
